### PR TITLE
Add PSSH_NUMNODES environmental variable on remote hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
+依云 <lilydjwg at gmail.com>
 Andrew McNabb <amcnabb at mcnabbs.org>
 Brent Chun <bnc at theether.org>

--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,4 @@
+Copyright (c) 2018, Jeffrey Lund
 Copyright (c) 2016-2017, lilydjwg
 Copyright (c) 2009-2012, Andrew McNabb
 Copyright (c) 2003-2008, Brent N. Chun

--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
-Copyright (c) 2016, lilydjwg
-Copyright (c) 2009, Andrew McNabb
+Copyright (c) 2016-2017, lilydjwg
+Copyright (c) 2009-2012, Andrew McNabb
 Copyright (c) 2003-2008, Brent N. Chun
 
 All rights reserved.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
+2018-09-29 Jeffrey Lund <jefflund at gmail.com>
+	* Version 2.3.3
+	  - Added PSSH_NUMNODES enviroment variable
+	  - Added pardo helpers to psshlib
 2017-09-14 依云 <lilydjwg at gmail.com>
 	* Version 2.3.2
-	  - Added PSSH_NUMNODES enviroment variable  Thanks to jefflund
-	    for the patch.
 	  - Remove support for Python 2.4
 	  - Many small fixes and code cleanup
 2012-02-02 Andrew McNabb <amcnabb at mcnabbs.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2017-09-14 依云 <lilydjwg at gmail.com>
+	* Version 2.3.2
+	  - Added PSSH_NUMNODES enviroment variable  Thanks to jefflund
+	    for the patch.
+	  - Remove support for Python 2.4
+	  - Many small fixes and code cleanup
 2012-02-02 Andrew McNabb <amcnabb at mcnabbs.org>
 	* Version 2.3.1
 	  - Fixed a problem where man pages were omitted from the tar file.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PSSH provides parallel versions of OpenSSH and related tools, including pssh, pscp, prsync, pnuke and pslurp. This project includes psshlib which can be used within custom applications. The source code is written in Python
+PSSH provides parallel versions of OpenSSH and related tools, including pssh, pscp, prsync, pnuke and pslurp. This project includes psshlib which can be used within custom applications. The source code is written in Python.
 
 PSSH is supported on Python 2.5 and later (including Python 3.1 and later). It was originally written and maintained by Brent N. Chun. Due to his busy schedule, Brent handed over maintenance to Andrew McNabb in October 2009.
 

--- a/bin/prsync
+++ b/bin/prsync
@@ -11,7 +11,6 @@ Note that remote must be an absolute path.
 """
 
 import os
-import re
 import sys
 
 parent, bindir = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/bin/pscp
+++ b/bin/pscp
@@ -12,7 +12,6 @@ remote must be an absolute path.
 """
 
 import os
-import re
 import sys
 
 parent, bindir = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/bin/pslurp
+++ b/bin/pslurp
@@ -12,7 +12,6 @@ outdir/<node>/local.  This program also uses the -q (quiet) and -C
 """
 
 import os
-import re
 import sys
 
 parent, bindir = os.path.split(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/bin/pssh
+++ b/bin/pssh
@@ -73,7 +73,7 @@ def do_pssh(hosts, cmdline, opts):
     manager = Manager(opts)
     for host, port, user in hosts:
         cmd = ['ssh', '-T', host, '-o', 'NumberOfPasswordPrompts=1',
-                '-o', 'SendEnv=PSSH_NODENUM PSSH_HOST']
+                '-o', 'SendEnv=PSSH_NODENUM PSSH_NUMNODES PSSH_HOST']
         if opts.options:
             for opt in opts.options:
                 cmd += ['-o', opt]

--- a/bin/pssh
+++ b/bin/pssh
@@ -12,7 +12,6 @@ directory.  Each output file in that directory will be named by the
 corresponding remote node's hostname or IP address.
 """
 
-import fcntl
 import os
 import sys
 

--- a/man/man1/pssh.1
+++ b/man/man1/pssh.1
@@ -63,14 +63,15 @@ is a program for executing ssh in parallel on a number of hosts.  It provides
 features such as sending input to all of the processes, passing a password
 to ssh, saving output to files, and timing out.
 
-The PSSH_NODENUM and PSSH_HOST environment variables are sent to the remote
-host.  The PSSH_NODENUM variable is assigned a unique number for each ssh
-connection, starting with 0 and counting up.  The PSSH_HOST variable is
-assigned the name of the host as specified in the hosts list.  Note that sshd
-drops environment variables by default, so sshd_config on the remote host must
-include the line:
+The PSSH_NODENUM, PSSH_NUMNODES, PSSH_HOST environment variables are sent to
+the remote host.  The PSSH_NODENUM variable is assigned a unique number for
+each ssh connection, starting with 0 and counting up.  The PSSH_NUMNODES
+variable is assigned the total number of node being used. The PSSH_HOST
+variable is assigned the name of the host as specified in the hosts list.  Note
+that sshd drops environment variables by default, so sshd_config on the remote
+host must include the line:
 .RS
-AcceptEnv PSSH_NODENUM PSSH_HOST
+AcceptEnv PSSH_NODENUM PSSH_NUMNODES PSSH_HOST
 .RE
 
 .SH OPTIONS

--- a/psshlib/__init__.py
+++ b/psshlib/__init__.py
@@ -1,0 +1,3 @@
+from .pardo import pardo, prange, penumerate, pproduct
+
+__all__ = ['pardo', 'prange', 'penumerate', 'pproduct']

--- a/psshlib/manager.py
+++ b/psshlib/manager.py
@@ -42,7 +42,8 @@ class Manager(object):
         self.errdir = opts.errdir
         self.iomap = make_iomap()
 
-        self.taskcount = 0
+        self.next_nodenum = 0
+        self.numnodes = 0
         self.tasks = []
         self.running = []
         self.done = []
@@ -113,6 +114,7 @@ class Manager(object):
     def add_task(self, task):
         """Adds a Task to be processed with run()."""
         self.tasks.append(task)
+        self.numnodes += 1
 
     def update_tasks(self, writer):
         """Reaps tasks and starts as many new ones as allowed."""
@@ -137,8 +139,8 @@ class Manager(object):
         while 0 < len(self.tasks) and len(self.running) < self.limit:
             task = self.tasks.pop(0)
             self.running.append(task)
-            task.start(self.taskcount, self.iomap, writer, self.askpass_socket)
-            self.taskcount += 1
+            task.start(self.next_nodenum, self.numnodes, self.iomap, writer, self.askpass_socket)
+            self.next_nodenum += 1
 
     def reap_tasks(self):
         """Checks to see if any tasks have terminated.

--- a/psshlib/pardo.py
+++ b/psshlib/pardo.py
@@ -1,0 +1,41 @@
+import itertools
+import os
+
+NODE_NUM = int(os.environ.get('PSSH_NODENUM', '0'))
+NUM_NODES = int(os.environ.get('PSSH_NUMNODES', '1'))
+
+
+def pardo(xs):
+    """
+    Helper function for splitting up work using pssh. Assuming the
+    environmental variables PSSH_NODENUM and PSSH_NUMNODES are set, will yield
+    only the subset of xs which corespond to this node's work. If these
+    variables are not set, then every value of xs will be yielded.
+    """
+    task_no = -1
+    for i, x in enumerate(xs):
+        task_no += 1
+        if task_no % NUM_NODES != NODE_NUM:
+            continue
+        yield x
+
+
+def prange(*args):
+    """
+    A shortcut for pardo(range(*args)).
+    """
+    yield from pardo(range(*args))
+
+
+def penumerate(iterable, start=0):
+    """
+    A shortchut for pardo(enumerate(iterable, start=start)).
+    """
+    yield from pardo(enumerate(iterable, start=start))
+
+
+def pproduct(*iterables, repeat=1):
+    """
+    A shortcut for pardo(itertools.product(*iterables, repeat=repeat)).
+    """
+    yield from pardo(itertools.product(*iterables, repeat=repeat))

--- a/psshlib/pardo.py
+++ b/psshlib/pardo.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2018, Jeffrey Lund
+
 import itertools
 import os
 

--- a/psshlib/psshutil.py
+++ b/psshlib/psshutil.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2003-2008, Brent N. Chun
 
 import fcntl
-import string
 import sys
 
 HOST_FORMAT = 'Host format is [user@]host[:port] [user]'

--- a/psshlib/task.py
+++ b/psshlib/task.py
@@ -69,7 +69,7 @@ class Task(object):
         except AttributeError:
             self.inline_stdout = False
 
-    def start(self, nodenum, iomap, writer, askpass_socket=None):
+    def start(self, nodenum, numnodes, iomap, writer, askpass_socket=None):
         """Starts the process and registers files with the IOMap."""
         self.writer = writer
 
@@ -79,6 +79,7 @@ class Task(object):
         # Set up the environment.
         environ = os.environ.copy()
         environ['PSSH_NODENUM'] = str(nodenum)
+        environ['PSSH_NUMNODES'] = str(numnodes)
         environ['PSSH_HOST'] = self.host
         # Disable the GNOME pop-up password dialog and allow ssh to use
         # askpass.py to get a provided password.  If the module file is

--- a/psshlib/task.py
+++ b/psshlib/task.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2018, Jeffrey Lund
 # Copyright (c) 2009-2012, Andrew McNabb
 
 from errno import EINTR

--- a/psshlib/version.py
+++ b/psshlib/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.3.2'
+VERSION = '2.3.3'

--- a/psshlib/version.py
+++ b/psshlib/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.3.1'
+VERSION = '2.3.2'


### PR DESCRIPTION
At least according to https://admin.fedoraproject.org/pkgdb/package/rpms/pssh this seems to be the upstream for pssh in the Fedora repos. If this is not the correct place to make this change then I apologize.

This PR adds in an environmental variable `PSSH_NUMNODES` which gives the total number of nodes being used. Combined with the existing `PSSH_NODENUM`, this allows scripts to programmatically determine what work to do, as `PSSH_NUMNODES` lets you compute how to divide up a task, and `PSSH_NODENUM` lets you compute which chunk of work to perform.