### PR TITLE
Add flag fort file write behaviour to append over recreate

### DIFF
--- a/psshlib/cli.py
+++ b/psshlib/cli.py
@@ -39,6 +39,8 @@ def common_parser():
             help='output directory for stdout files (OPTIONAL)')
     parser.add_option('-e', '--errdir', dest='errdir',
             help='output directory for stderr files (OPTIONAL)')
+    parser.add_option('--fileappend', dest='fileappend', action='store_true',
+            help='append to existing output/error files, creates file(s) if missing (OPTIONAL)')
     parser.add_option('-t', '--timeout', dest='timeout', type='int',
             help='timeout (secs) (0 = no timeout) per host (OPTIONAL)')
     parser.add_option('-O', '--option', dest='options', action='append',

--- a/psshlib/manager.py
+++ b/psshlib/manager.py
@@ -36,6 +36,7 @@ class Manager(object):
         self.askpass = opts.askpass
         self.outdir = opts.outdir
         self.errdir = opts.errdir
+        self.fileappend = opts.fileappend
         self.iomap = make_iomap()
 
         self.next_nodenum = 0
@@ -50,7 +51,7 @@ class Manager(object):
         """Processes tasks previously added with add_task."""
         try:
             if self.outdir or self.errdir:
-                writer = Writer(self.outdir, self.errdir)
+                writer = Writer(self.outdir, self.errdir, self.fileappend)
                 writer.start()
             else:
                 writer = None
@@ -314,13 +315,18 @@ class Writer(threading.Thread):
     EOF = object()
     ABORT = object()
 
-    def __init__(self, outdir, errdir):
+    def __init__(self, outdir, errdir, fileappend):
         threading.Thread.__init__(self)
         # A daemon thread automatically dies if the program is terminated.
         self.setDaemon(True)
         self.queue = queue.Queue()
         self.outdir = outdir
         self.errdir = errdir
+
+        if fileappend:
+            self.filewritemode = 'ab'
+        else:
+            self.filewritemode = 'wb'
 
         self.host_counts = {}
         self.files = {}
@@ -341,7 +347,7 @@ class Writer(threading.Thread):
                 else:
                     if dest is None:
                         dest = self.files[filename] = open(
-                            filename, 'ab', buffering=1)
+                            filename, self.filewritemode, buffering=1)
                         psshutil.set_cloexec(dest)
                     dest.write(data)
                     dest.flush()

--- a/psshlib/manager.py
+++ b/psshlib/manager.py
@@ -341,7 +341,7 @@ class Writer(threading.Thread):
                 else:
                     if dest is None:
                         dest = self.files[filename] = open(
-                            filename, 'wb', buffering=1)
+                            filename, 'ab', buffering=1)
                         psshutil.set_cloexec(dest)
                     dest.write(data)
                     dest.flush()


### PR DESCRIPTION
This change makes the err and out files append data instead of overwriting it.

This helps when running prsync as a cronjob so that logs are not removed after a new failure