### PR TITLE
bin/*: explicitly run with python3

### DIFF
--- a/bin/pnuke
+++ b/bin/pnuke
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: python -*-
 
 # Copyright (c) 2009-2012, Andrew McNabb

--- a/bin/prsync
+++ b/bin/prsync
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: python -*-
 
 # Copyright (c) 2009-2012, Andrew McNabb

--- a/bin/pscp
+++ b/bin/pscp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: python -*-
 
 # Copyright (c) 2009-2012, Andrew McNabb

--- a/bin/pslurp
+++ b/bin/pslurp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: python -*-
 
 # Copyright (c) 2009-2012, Andrew McNabb

--- a/bin/pssh
+++ b/bin/pssh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: python -*-
 
 # Copyright (c) 2009-2012, Andrew McNabb

--- a/bin/pssh-askpass
+++ b/bin/pssh-askpass
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
This changes the `#!/usr/bin/env python` line to `#!/usr/bin/env python3` in all utils in the bin directory.

On some systems, `/usr/bin/env python` still resolves to python2 even if python3 is installed. For instance, it's the case on my machine with macOS Big Sur. This is what happens:
```
Traceback (most recent call last):
  File "./pssh", line 22, in <module>
    from psshlib import psshutil
  File "/Users/ch1p/pssh/psshlib/__init__.py", line 1, in <module>
    from .pardo import pardo, prange, penumerate, pproduct
  File "/Users/ch1p/pssh/psshlib/pardo.py", line 29
    yield from pardo(range(*args))
             ^
SyntaxError: invalid syntax
```

I suppose it makes sense to explicitly run it with python3 since it's a python3.5+ fork anyway.