### PR TITLE
Allow `prsync --download` commands to be repeated usefully

### DIFF
--- a/bin/prsync
+++ b/bin/prsync
@@ -95,7 +95,8 @@ def do_prsync(hosts, local, remote, opts):
             else:
                 cmd.append('%s:%s' % (host, local[0]))
             localpath = "%s/%s" % (remote, host)
-            os.makedirs(localpath)
+            # Without `exist_ok=True`, iterative `--download` is impossible:
+            os.makedirs(localpath, exist_ok=True)
             cmd.append(localpath)
         else:
             cmd.extend(local)


### PR DESCRIPTION
A common use-case of `rsync` is to incrementally put or fetch updates, by repeating the same `rsync` command; `prsync` allowed this, except with `--download`. The current PR allows `--download` to work repeatedly, avoiding a `FileExistsError` that would be thrown by `os.makedirs`:
```
Traceback (most recent call last):
  File "/tmp/tmp.9Yhla77IAx/pssh/bin/prsync", line 134, in <module>
    do_prsync(hosts, local, remote, opts)
  File "/tmp/tmp.9Yhla77IAx/pssh/bin/prsync", line 98, in do_prsync
    os.makedirs(localpath)
  File "<frozen os>", line 225, in makedirs
FileExistsError: [Errno 17] File exists: '<path redacted>'
```
